### PR TITLE
Add eslint-import-resolver-typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,7 @@ module.exports = {
       parser: '@typescript-eslint/parser',
       settings: {
         'import/resolver': {
-          node: {
-            extensions: ['.js', '.jsx', '.ts', '.tsx'],
-          },
+          typescript: { },
         },
       },
       rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -615,6 +615,18 @@
         }
       }
     },
+    "eslint-import-resolver-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz",
+      "integrity": "sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      }
+    },
     "eslint-module-utils": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
@@ -906,8 +918,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -934,7 +945,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1053,7 +1063,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1062,8 +1071,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1376,7 +1384,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1441,8 +1448,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -1954,8 +1960,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-portsoc": "^0.8.1",
     "eslint-config-semistandard": "^15.0.1",
     "eslint-config-standard": "^16.0.2",
+    "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.3.1",

--- a/tests/files/import-extensions-1-bad.ts
+++ b/tests/files/import-extensions-1-bad.ts
@@ -1,3 +1,4 @@
 import './no-shadow-good';
 import './indent-good';
+import './member-delimiter-good.js';
 import '../test.js'; // bad

--- a/tests/files/import-extensions-2-bad.ts
+++ b/tests/files/import-extensions-2-bad.ts
@@ -1,3 +1,4 @@
 import './no-shadow-good.ts'; // bad
 import './indent-good';
+import './member-delimiter-good.js';
 import '../test';

--- a/tests/files/import-extensions-good.ts
+++ b/tests/files/import-extensions-good.ts
@@ -1,3 +1,4 @@
 import './no-shadow-good';
 import './indent-good';
+import './member-delimiter-good.js';
 import '../test';


### PR DESCRIPTION
Added eslint-import-resolver-typescript to the settings to prevent eslint import/no-unresolved errors on .ts files.
Added a .js import of a .ts file in import-extensions-good.ts for testing purposes.