### PR TITLE
require space before => in type annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,12 @@ module.exports = {
         '@typescript-eslint/type-annotation-spacing': ['error', {
           before: false,
           after: true,
+          overrides: {
+            arrow: {
+              before: true,
+              after: true,
+            },
+          },
         }],
       },
     },

--- a/tests/files/type-annotation-spacing-arrow-1-bad.ts
+++ b/tests/files/type-annotation-spacing-arrow-1-bad.ts
@@ -1,0 +1,10 @@
+export default {}; // treat this file as a module
+function foobar(foo: (x: string)=>boolean, bar: string) {
+  return foo(bar);
+}
+
+function isBar(x: string) {
+  return x === 'bar';
+}
+
+foobar(isBar, 'bar');

--- a/tests/files/type-annotation-spacing-arrow-2-bad.ts
+++ b/tests/files/type-annotation-spacing-arrow-2-bad.ts
@@ -1,0 +1,10 @@
+export default {}; // treat this file as a module
+function foobar(foo: (x: string) =>boolean, bar: string) {
+  return foo(bar);
+}
+
+function isBar(x: string) {
+  return x === 'bar';
+}
+
+foobar(isBar, 'bar');

--- a/tests/files/type-annotation-spacing-arrow-3-bad.ts
+++ b/tests/files/type-annotation-spacing-arrow-3-bad.ts
@@ -1,0 +1,10 @@
+export default {}; // treat this file as a module
+function foobar(foo: (x: string)=> boolean, bar: string) {
+  return foo(bar);
+}
+
+function isBar(x: string) {
+  return x === 'bar';
+}
+
+foobar(isBar, 'bar');

--- a/tests/files/type-annotation-spacing-arrow-good.ts
+++ b/tests/files/type-annotation-spacing-arrow-good.ts
@@ -1,0 +1,10 @@
+export default {}; // treat this file as a module
+function foobar(foo: (x: string) => boolean, bar: string) {
+  return foo(bar);
+}
+
+function isBar(x: string) {
+  return x === 'bar';
+}
+
+foobar(isBar, 'bar');


### PR DESCRIPTION
Added overrides for rule `@typescript-eslint/type-annotation-spacing` to require space before => in type annotations